### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pyssltest.py
+++ b/pyssltest.py
@@ -417,7 +417,7 @@ while read_line is not "":
 	
 total_lines = line_no - 1
 
-print "There are %d Urls read from the File" % (total_lines)
+print "There are {0:d} Urls read from the File".format((total_lines))
 
 #print mainapps
 print "\n No of URLs is identified is " + str(len(mainapps))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyssltest?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyssltest?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
